### PR TITLE
Fix role assignment -- only complain in updateGroup() when necesssary.

### DIFF
--- a/Products/PloneLDAP/mixins/groupmgmt.py
+++ b/Products/PloneLDAP/mixins/groupmgmt.py
@@ -42,7 +42,10 @@ class GroupManagementMixin:
 
     security.declarePrivate('updateGroup')
     def updateGroup(self, id, **kw):
-        raise NotImplementedError()
+        # Don't complain unless we are actually asked to do something.
+        values = [v for v in kw.values() if v is not None]
+        if len(values) > 0:
+            raise NotImplementedError()
 
     security.declarePrivate('setRolesForGroup')
     def setRolesForGroup(self, group_id, roles=()):


### PR DESCRIPTION
This fixes role assignment via the Plone Users and Groups control panel,
which calls updateGroup() before actually setting roles (role setting is done
by portal_role_manager and doesn't concern us).  If we don't get any non-None
arguments, don't raise an exception.

Attempting to set group properties (title, description, email) from Plone
will pass in actual values (or an empty string, but not None) and in that case
the exception is still appropriately raised.

Perhaps Plone shouldn't be calling this (the caller is
Products.PlonePAS.tools.groups.editGroup(); for role assignment it does
not have title or description in its **kw, and thus ends up calling
updateGroup(id, title=None, description=None)), but working around it here is
easy enough.
