### PR TITLE
default _extra_user_filter typo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,14 @@ Changes
 1.3 (unreleased)
 ----------------
 
+* Fix typo for custom extra_user_filter.
+  See comments below about "When creating an Active Directory plugin
+  ... ignore disabled or non-user accounts ..."
+  [mamico]
+
 * Remove duplicate line with no effect.
   [saily]
+
 * Support mapping LDAP groups to Plone roles via the Users and Groups
   control panel.
   [adaugherity]

--- a/Products/PloneLDAP/factory.py
+++ b/Products/PloneLDAP/factory.py
@@ -136,7 +136,7 @@ def manage_addPloneActiveDirectoryMultiPlugin(self, id, title,
     # used by services such as IIS (PASSWD_NOTREQD flag)
     filters.append("(!(userAccountControl:1.2.840.113556.1.4.803:=32))")
 
-    luf._extra_user_filer = "(&%s)" % "".join(filters)
+    luf._extra_user_filter = "(&%s)" % "".join(filters)
 
     # Redirect back to the user folder
     if REQUEST is not None:

--- a/Products/PloneLDAP/tests/testCreation.py
+++ b/Products/PloneLDAP/tests/testCreation.py
@@ -50,6 +50,12 @@ class TestADCreation(TestLDAPCreation):
                 PloneActiveDirectoryMultiPlugin.meta_type)
 
 
+    def testADAttributes(self):
+        luf=self.folder.ldap._getLDAPUserFolder()
+        self.assertEqual(luf._extra_user_filter,
+            '(&(!(userAccountControl:1.2.840.113556.1.4.803:=2))'
+            '(userAccountControl:1.2.840.113556.1.4.803:=512)'
+            '(!(userAccountControl:1.2.840.113556.1.4.803:=32)))')
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
Probably need to say something about this change on documentation if merged this fix... 
default extra_user_filter was empty for years because of this typo.