### PR TITLE
Fix setProperties None value fullname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.3 (unreleased)
 ----------------
 
+* Fix setProperties to not set a None value.
+  [allusa]
+
 * Fix typo for custom extra_user_filter.
   See comments below about "When creating an Active Directory plugin
   ... ignore disabled or non-user accounts ..."

--- a/Products/PloneLDAP/property.py
+++ b/Products/PloneLDAP/property.py
@@ -66,6 +66,8 @@ class LDAPPropertySheet(UserPropertySheet):
             #the value in the mapping is an utf-8 encoded byte string, while self._properties
             #stores unicode object. this is NOT the same as of python 2.x, python 3 will handle
             #that differently
+            if value is None:
+                continue
             value=safe_unicode(value)
             if key in schema and self._properties[key]!=value:
                 if schema[key][1]=="lines":


### PR DESCRIPTION
Do not parse in setProperties when a field is not required and thus it is a None value, e.g. fullname field.
@bloodbare 