### PR TITLE
Zope 4 compatibility: Replaced broken imports of InitializeClass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Changes
   control panel.
   [adaugherity]
 
+* Zope 4 compatibility: Replaced broken imports of InitializeClass.
+  [reinhardt]
+
 
 1.2 (2012-11-30)
 ----------------

--- a/Products/PloneLDAP/mixins/groupcaps.py
+++ b/Products/PloneLDAP/mixins/groupcaps.py
@@ -1,5 +1,5 @@
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 
 class GroupCapabilityMixin:
     """Implement Products.PlonePAS.interfaces.capabilities.IGroupCapability

--- a/Products/PloneLDAP/mixins/groupintro.py
+++ b/Products/PloneLDAP/mixins/groupintro.py
@@ -1,5 +1,5 @@
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 
 class GroupIntrospectionMixin:
     """Implement Products.PlonePAS.interfaces.plugins.IGroupIntrospection

--- a/Products/PloneLDAP/mixins/groupmgmt.py
+++ b/Products/PloneLDAP/mixins/groupmgmt.py
@@ -1,5 +1,5 @@
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 
 
 class GroupManagementMixin:

--- a/Products/PloneLDAP/mixins/useradder.py
+++ b/Products/PloneLDAP/mixins/useradder.py
@@ -1,6 +1,6 @@
 import logging
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 
 logger = logging.getLogger("PloneLDAP")
 

--- a/Products/PloneLDAP/mixins/usermgmt.py
+++ b/Products/PloneLDAP/mixins/usermgmt.py
@@ -1,5 +1,5 @@
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 
 class UserManagementMixin:
     """Implement Products.PlonePAS.interfaces.plugins.IUserManagement,

--- a/Products/PloneLDAP/mixins/userprops.py
+++ b/Products/PloneLDAP/mixins/userprops.py
@@ -1,5 +1,5 @@
-from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 from Products.PloneLDAP.property import LDAPPropertySheet
 
 class UserPropertiesMixin:

--- a/Products/PloneLDAP/plugins/ad.py
+++ b/Products/PloneLDAP/plugins/ad.py
@@ -1,7 +1,7 @@
 import logging
 from zope.interface import implementedBy
 from AccessControl import ClassSecurityInfo
-from Globals import InitializeClass
+from AccessControl.class_init import InitializeClass
 from Products.LDAPMultiPlugins.ActiveDirectoryMultiPlugin import (
     ActiveDirectoryMultiPlugin)
 from Products.PluggableAuthService.interfaces.plugins import (

--- a/Products/PloneLDAP/plugins/base.py
+++ b/Products/PloneLDAP/plugins/base.py
@@ -1,7 +1,7 @@
 import logging
-from Globals import InitializeClass
 from Acquisition import aq_base
 from AccessControl import ClassSecurityInfo
+from AccessControl.class_init import InitializeClass
 from Products.PluggableAuthService.utils import createViewName
 from Products.PluggableAuthService.PluggableAuthService import \
         _SWALLOWABLE_PLUGIN_EXCEPTIONS

--- a/Products/PloneLDAP/plugins/ldap.py
+++ b/Products/PloneLDAP/plugins/ldap.py
@@ -1,7 +1,7 @@
 import logging
 from zope.interface import implementedBy
 from AccessControl import ClassSecurityInfo
-from Globals import InitializeClass
+from AccessControl.class_init import InitializeClass
 from Products.LDAPMultiPlugins.LDAPMultiPlugin import LDAPMultiPlugin
 from Products.PluggableAuthService.interfaces.plugins import (
     IUserEnumerationPlugin, IGroupsPlugin, IGroupEnumerationPlugin,


### PR DESCRIPTION
The Globals module had been deprecated and now has gone away in Zope 4. The recommended way to go is to import from AccessControl.class_init instead.